### PR TITLE
Add get caller benchmarks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jmh.version>1.21</jmh.version>
+    <jmh.version>1.26</jmh.version>
     <java.version>11</java.version>
     <uberjar.name>benchmarks</uberjar.name>
   </properties>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.4</version>
+      <version>2.8.6</version>
     </dependency>
 
     <dependency>
@@ -33,13 +33,13 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.4</version>
+      <version>3.11</version>
     </dependency>
 
     <dependency>
       <groupId>org.jfree</groupId>
       <artifactId>jfreechart</artifactId>
-      <version>1.0.19</version>
+      <version>1.5.1</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,13 +48,6 @@
       <version>2.4.0</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.openjdk.jmh</groupId>
-      <artifactId>jmh-generator-annprocess</artifactId>
-      <version>${jmh.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
   </dependencies>
 
   <build>
@@ -62,16 +55,23 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.8.1</version>
         <configuration>
           <release>${java.version}</release>
+          <annotationProcessorPaths>
+            <annotationProcessorPath>
+              <groupId>org.openjdk.jmh</groupId>
+              <artifactId>jmh-generator-annprocess</artifactId>
+              <version>${jmh.version}</version>
+            </annotationProcessorPath>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.2</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -109,7 +109,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>2.6.1</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
@@ -121,27 +121,27 @@
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.3</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>2.7</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.4</version>
+          <version>3.9.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-source-plugin</artifactId>
-          <version>2.4</version>
+          <version>3.2.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.18.1</version>
+          <version>2.22.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmh.version>1.21</jmh.version>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <uberjar.name>benchmarks</uberjar.name>
   </properties>
 
@@ -64,8 +64,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
 

--- a/src/main/java/com/github/ferstl/jmhexperiments/ChartFucker.java
+++ b/src/main/java/com/github/ferstl/jmhexperiments/ChartFucker.java
@@ -4,8 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-
-import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.CategoryAxis;
 import org.jfree.chart.axis.NumberAxis;
@@ -22,17 +21,17 @@ import org.supercsv.prefs.CsvPreference;
 
 public class ChartFucker {
 
-  private static final String[] CSV_COLUMNS = { "benchmark", "mode", "threads", "samples", "score", "error", "unit" };
-  private static final CellProcessor[] CSV_CELL_PROCESSORS = {null, null, new ParseInt(), new ParseInt(), new ParseDouble(), new ParseDouble(), null };
+  private static final String[] CSV_COLUMNS = {"benchmark", "mode", "threads", "samples", "score", "error", "unit"};
+  private static final CellProcessor[] CSV_CELL_PROCESSORS = {null, null, new ParseInt(), new ParseInt(), new ParseDouble(), new ParseDouble(), null};
 
   public static void fuck(String fileName) {
-    try(CsvBeanReader csvReader = new CsvBeanReader(Files.newBufferedReader(Paths.get(fileName)), CsvPreference.STANDARD_PREFERENCE)) {
+    try (CsvBeanReader csvReader = new CsvBeanReader(Files.newBufferedReader(Paths.get(fileName)), CsvPreference.STANDARD_PREFERENCE)) {
       // skip the header
       csvReader.getHeader(true);
 
       DefaultStatisticalCategoryDataset ds = new DefaultStatisticalCategoryDataset();
       CsvEntry entry;
-      while((entry = csvReader.read(CsvEntry.class, CSV_COLUMNS, CSV_CELL_PROCESSORS)) != null) {
+      while ((entry = csvReader.read(CsvEntry.class, CSV_COLUMNS, CSV_CELL_PROCESSORS)) != null) {
         addToDataSet(ds, entry);
       }
 
@@ -45,7 +44,7 @@ public class ChartFucker {
 
       JFreeChart chart = new JFreeChart(plot);
       chart.removeLegend();
-      ChartUtilities.saveChartAsPNG(getChartFile(fileName), chart, 600, 300);
+      ChartUtils.saveChartAsPNG(getChartFile(fileName), chart, 600, 300);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/com/github/ferstl/jmhexperiments/getcaller/GetCaller.java
+++ b/src/main/java/com/github/ferstl/jmhexperiments/getcaller/GetCaller.java
@@ -1,0 +1,42 @@
+package com.github.ferstl.jmhexperiments.getcaller;
+
+import java.lang.StackWalker.Option;
+import java.lang.StackWalker.StackFrame;
+import java.lang.invoke.MethodHandles;
+import java.util.EnumSet;
+import static java.lang.StackWalker.Option.RETAIN_CLASS_REFERENCE;
+
+public class GetCaller {
+
+  private static final StackWalker STACK_WALKER_FOR_CLASS = StackWalker.getInstance(EnumSet.of(RETAIN_CLASS_REFERENCE), 2);
+
+  private static final StackWalker STACK_WALKER_FOR_CLASS_NAME = StackWalker.getInstance(EnumSet.noneOf(Option.class), 2);
+
+  public static Class<?> getCallerClassByLookup() {
+    return MethodHandles.lookup().lookupClass();
+  }
+
+  public static Class<?> getCallerClassByStackWalker() {
+    return STACK_WALKER_FOR_CLASS.walk(s -> s.skip(1)
+        .map(StackFrame::getDeclaringClass)
+        .findFirst()
+        .get());
+  }
+
+  public static String getCallerClassNameByStackWalker() {
+    return STACK_WALKER_FOR_CLASS_NAME.walk(s -> s.skip(1)
+        .map(StackFrame::getClassName)
+        .findFirst()
+        .get());
+  }
+
+  public static String getCallerClassNameByException() {
+    return new RuntimeException().getStackTrace()[1].getClassName();
+  }
+
+  // public static Class<?> getCallerClassByReflection() {
+  // return sun.reflect.Reflection.getCallerClass();
+  // return jdk.internal.reflect.Reflection.getCallerClass()();
+  // }
+
+}

--- a/src/main/java/com/github/ferstl/jmhexperiments/getcaller/GetCallerBenchmark.java
+++ b/src/main/java/com/github/ferstl/jmhexperiments/getcaller/GetCallerBenchmark.java
@@ -1,0 +1,56 @@
+package com.github.ferstl.jmhexperiments.getcaller;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import com.github.ferstl.jmhexperiments.ChartFucker;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+
+/**
+ * Benchmarks for different ways to get the caller of a method.
+ */
+@BenchmarkMode(AverageTime)
+@OutputTimeUnit(MICROSECONDS)
+public class GetCallerBenchmark {
+
+  public static void main(String[] args) throws RunnerException {
+    String fileName = "getcaller-result.csv";
+    Options options = new OptionsBuilder()
+        .include(".*GetCallerBenchmark.*")
+        .warmupIterations(3)
+        .measurementIterations(5)
+        .resultFormat(ResultFormatType.CSV)
+        .result(fileName)
+        .build();
+    new Runner(options).run();
+
+    ChartFucker.fuck(options.getResult().orElse(fileName));
+  }
+
+  @Benchmark
+  public Class<?> getCallerClassByStackWalker() {
+    return GetCaller.getCallerClassByStackWalker();
+  }
+
+  @Benchmark
+  public String getCallerClassNameByStackWalker() {
+    return GetCaller.getCallerClassNameByStackWalker();
+  }
+
+  @Benchmark
+  public Class<?> getCallerClassByLookup() {
+    return GetCaller.getCallerClassByLookup();
+  }
+
+  @Benchmark
+  public String getCallerClassNameByException() {
+    return GetCaller.getCallerClassNameByException();
+  }
+
+}


### PR DESCRIPTION
Add benchmarks that explore the performance of different ways to get the caller class.

In addition this pull request contains the following changes

* upgrade to Java 11
* update the dependencies
* update the plugins
* configure the JMH annotation processor as an annotation processor

The upgrade to Java 11 has the advantage that we can benchmark `java.lang.StackWalker` but has the disadvantage that we can no longer benchmark `sun.reflect.Reflection#getCallerClass()` we could in theory benchmark `jdk.internal.reflect.Reflection#getCallerClass()` but that would require messing with JVM options.