### PR TITLE
MethodHandle improvements

### DIFF
--- a/src/main/java/com/github/ferstl/jmhexperiments/methodhandle/MethodHandleBenchmark.java
+++ b/src/main/java/com/github/ferstl/jmhexperiments/methodhandle/MethodHandleBenchmark.java
@@ -32,6 +32,7 @@ public class MethodHandleBenchmark {
   public static void main(String[] args) throws RunnerException {
     Options options = new OptionsBuilder()
       .include(".*MethodHandleBenchmark.*")
+      .forks(1)
       .warmupIterations(10)
       .measurementIterations(10)
       .resultFormat(ResultFormatType.CSV)
@@ -42,49 +43,41 @@ public class MethodHandleBenchmark {
     ChartFucker.fuck(options.getResult().orElse("jmh-result.csv"));
   }
 
-  @Fork(1)
   @Benchmark
   public double baselineVirtual(TestObject state) {
     return state.testMethod();
   }
 
-  @Fork(1)
   @Benchmark
   public double reflectionVirtual(TestObject state) throws Exception {
     return (double) state.method.invoke(state);
   }
 
-  @Fork(1)
   @Benchmark
   public double methodHandleVirtual(TestObject state) throws Throwable {
     return (double) state.methodHandle.invoke(state);
   }
 
-  @Fork(1)
   @Benchmark
   public double boundMethodHandleVirtual(TestObject state) throws Throwable {
     return (double) state.boundMethodHandle.invoke();
   }
 
-  @Fork(1)
   @Benchmark
   public double baselineStatic(TestObject state) {
     return TestObject.staticTestMethod(state);
   }
 
-  @Fork(1)
   @Benchmark
   public double reflectionStatic(TestObject state) throws Exception {
     return (double) state.staticMethod.invoke(null, state);
   }
 
-  @Fork(1)
   @Benchmark
   public double methodHandleStatic(TestObject state) throws Throwable {
     return (double) state.staticMethodHandle.invoke(state);
   }
 
-  @Fork(1)
   @Benchmark
   public double boundMethodHandleStatic(TestObject state) throws Throwable {
     return (double) state.staticBoundMethodHandle.invoke();

--- a/src/main/java/com/github/ferstl/jmhexperiments/methodhandle/MethodHandleBenchmark.java
+++ b/src/main/java/com/github/ferstl/jmhexperiments/methodhandle/MethodHandleBenchmark.java
@@ -102,16 +102,16 @@ public class MethodHandleBenchmark {
 
   @State(Scope.Thread)
   public static class TestObject {
-    private volatile int i;
-    private volatile double d;
+    private int i;
+    private double d;
 
-    private volatile Method method;
-    private volatile MethodHandle methodHandle;
-    private volatile MethodHandle boundMethodHandle;
+    private Method method;
+    private MethodHandle methodHandle;
+    private MethodHandle boundMethodHandle;
 
-    private volatile Method staticMethod;
-    private volatile MethodHandle staticMethodHandle;
-    private volatile MethodHandle staticBoundMethodHandle;
+    private Method staticMethod;
+    private MethodHandle staticMethodHandle;
+    private MethodHandle staticBoundMethodHandle;
 
     @Setup(Level.Trial)
     public void setup() throws Exception {

--- a/src/main/java/com/github/ferstl/jmhexperiments/methodhandle/MethodHandleBenchmark.java
+++ b/src/main/java/com/github/ferstl/jmhexperiments/methodhandle/MethodHandleBenchmark.java
@@ -59,8 +59,18 @@ public class MethodHandleBenchmark {
   }
 
   @Benchmark
+  public double methodHandleVirtualExact(TestObject state) throws Throwable {
+    return (double) state.methodHandle.invokeExact(state);
+  }
+
+  @Benchmark
   public double boundMethodHandleVirtual(TestObject state) throws Throwable {
     return (double) state.boundMethodHandle.invoke();
+  }
+
+  @Benchmark
+  public double boundMethodHandleVirtualExact(TestObject state) throws Throwable {
+    return (double) state.boundMethodHandle.invokeExact();
   }
 
   @Benchmark
@@ -79,8 +89,18 @@ public class MethodHandleBenchmark {
   }
 
   @Benchmark
+  public double methodHandleStaticExact(TestObject state) throws Throwable {
+    return (double) state.staticMethodHandle.invokeExact(state);
+  }
+
+  @Benchmark
   public double boundMethodHandleStatic(TestObject state) throws Throwable {
     return (double) state.staticBoundMethodHandle.invoke();
+  }
+
+  @Benchmark
+  public double boundMethodHandleStaticExact(TestObject state) throws Throwable {
+    return (double) state.staticBoundMethodHandle.invokeExact();
   }
 
 


### PR DESCRIPTION
Various improvements to `MethodHandleBenchmark`. See the individual commits

* move fork count to runner options
* add `#invokeExact` methods
* clean up setup implementation
* remove volatile
* add static final MethodHandles
